### PR TITLE
Add cst-dependencies rep in maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ repositories {
         url "https://artifacts.camunda.com/artifactory/public/"
     }
     maven { url 'https://jitpack.io' }
+    maven {
+        url 'https://cst-group.github.io/cst-dependencies/maven-repo/'
+    }
 }
 
 configurations {


### PR DESCRIPTION
Due to https://spring.io/blog/2024/12/02/repository-springsource-com-sunset some of the dependencies were missing so we added the libs to https://github.com/CST-Group/cst-dependencies